### PR TITLE
Update `init` task to work when no scene ID is provided

### DIFF
--- a/assets/StashInteractiveTools.py
+++ b/assets/StashInteractiveTools.py
@@ -17,7 +17,7 @@ if DEBUG:
     MODE = 'init'
 else:
     FRAGMENT = json.loads(sys.stdin.read())
-    MODE = FRAGMENT["args"]["mode"]
+    MODE = FRAGMENT["args"].get("mode", "init")
 
 stash = StashInterface(FRAGMENT["server_connection"])
 PLUGIN_DIR = FRAGMENT["server_connection"]['PluginDir']
@@ -110,7 +110,6 @@ def analyze_scene():
             return []
 
     return []
-
 
 
 SCENE_FRAGMENT = """

--- a/assets/StashInteractiveTools.py
+++ b/assets/StashInteractiveTools.py
@@ -87,12 +87,30 @@ def analyze_file(file, scene_id):
 
 
 def analyze_scene():
-    scene_id = FRAGMENT["args"]['scene_id']
-    scene = stash.find_scene(scene_id)
-    # log.info(json.dumps(scene))
-    if scene['interactive']:
-        return analyze_file(scene['files'][0]['path'], scene_id)
+    # Check if a scene ID is provided in FRAGMENT["args"]
+    if "scene_id" in FRAGMENT["args"]:
+        scene_id = FRAGMENT["args"]['scene_id']
+        scene = stash.find_scene(scene_id)
+        # log.info(json.dumps(scene))
+        if scene['interactive']:
+            return analyze_file(scene['files'][0]['path'], scene_id)
+    else:
+        # Otherwise, look for all interactive scenes
+        query = {"interactive": True}
+        scenes = stash.find_scenes(query)
+        if scenes:
+            results = []
+            for scene in scenes:
+                scene_id = scene["id"]
+                if scene['interactive']:
+                    result = analyze_file(scene['files'][0]['path'], scene_id)
+                    results.append(result)
+            return results
+        else:
+            return []
+
     return []
+
 
 
 SCENE_FRAGMENT = """


### PR DESCRIPTION
This fixes the widely reported issue where init task will crash and not analyze the interactive scenes in the library.

It seems that the current implementation always expect a `scene_id` to be present as an arg which is largely true if the task is spawned while playing a scene or if the scanner itself calls it (unclear how this works right now). This is fine but most users expect triggering the task manually from the Tasks tab to work and this resolves it.

I've tested this on my library and it solves the issue where funscript dropdowns were not populated on scenes with multiple tags.