### PR TITLE
Fix usage behind reverse proxy

### DIFF
--- a/assets/config.py
+++ b/assets/config.py
@@ -88,9 +88,8 @@ def get_config():
     stash = get_stash_client()
 
     config.PLUGIN_DIR = config.FRAGMENT["server_connection"]['PluginDir']
-    config.PLUGIN_HTTP_ASSETS_PATH = stash.url.replace('/graphql',
-                                                       '/plugin/StashInteractiveTools/assets').replace(
-        "127.0.0.1", config.FRAGMENT["args"].get("hostname", '127.0.0.1'))
+    origin = config.FRAGMENT["args"].get("origin", stash.url.replace('/graphql', ''))
+    config.PLUGIN_HTTP_ASSETS_PATH = f'{origin}/plugin/StashInteractiveTools/assets'
 
     c = stash.find_plugin_config(config.ID)
     config.ENABLE_TAGGING = bool(c.get('enable_tagging'))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -151,7 +151,7 @@ const InteractiveTools = ({ scene }: SceneFileInfoPanelProps) => {
         args: {
           mode: 'init',
           scene_id: scene.id,
-          hostname: window.location.hostname,
+          origin: window.location.origin,
         },
       },
     }).catch(console.error);


### PR DESCRIPTION
This fixes switching funscripts when Stash is behind a (https) reverse proxy.

Using `window.location.origin` provides the correct scheme://hostname:port for client access.